### PR TITLE
fix: change UMD output from .cjs to .js extension to resolve MIME type issue

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig(({ mode }) => {
 				entry: "src/prod.ts",
 				formats: ["umd"],
 				name: "n8n-embedded-chat-interface",
-				fileName: "index",
+				fileName: () => "index.js",
 			},
 			rollupOptions: {
 				external: [],


### PR DESCRIPTION
Fixes the MIME type issue where browsers reject scripts served from CDN due to incorrect MIME type detection.

## Changes
- Updated `vite.config.ts` to output `.js` extension instead of `.cjs` for UMD builds
- This ensures CDNs serve the file with `application/javascript` MIME type instead of `application/node`

Fixes #1

Generated with [Claude Code](https://claude.ai/code)